### PR TITLE
Fix desktop and mobile transaction UI

### DIFF
--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -31,7 +31,7 @@ table.ob-table {
     border-top-right-radius: $ob-table-border-radius;
   }
 
-  th#trx-header-mobile,
+  th#trx-actions,
   th#ob-stash-list {
     border-top-right-radius: $ob-table-border-radius;
   }

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -33,7 +33,6 @@ table.ob-table {
 
   th#trx-header-mobile,
   th#ob-stash-list {
-    border-top-left-radius: $ob-table-border-radius;
     border-top-right-radius: $ob-table-border-radius;
   }
 

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -31,8 +31,9 @@ table.ob-table {
     border-top-right-radius: $ob-table-border-radius;
   }
 
-  th#trx-actions,
+  th#trx-header-mobile,
   th#ob-stash-list {
+    border-top-left-radius: $ob-table-border-radius;
     border-top-right-radius: $ob-table-border-radius;
   }
 

--- a/app/assets/stylesheets/application.bulma.scss
+++ b/app/assets/stylesheets/application.bulma.scss
@@ -227,3 +227,27 @@ a.has-text-white.sortable {
     }
   }
 }
+
+// Mobile search field styling
+@media screen and (max-width: 768px) {
+  #transaction-search {
+    width: 100%;
+    
+    .field {
+      width: 100%;
+    }
+    
+    .control {
+      width: 100%;
+    }
+    
+    .input {
+      width: 100%;
+    }
+  }
+  
+  // Add bottom padding between mobile search and transactions table
+  nav.level.is-hidden-tablet {
+    margin-bottom: 1rem;
+  }
+}

--- a/app/views/transactions/components/_transactionList.html.erb
+++ b/app/views/transactions/components/_transactionList.html.erb
@@ -22,7 +22,7 @@
           Balance
         </div>
       </th>
-      <th class="has-text-right is-hidden-mobile" id="trx-header-mobile">
+      <th class="has-text-right is-hidden-mobile" id="trx-actions">
         <div>
           Actions
         </div>


### PR DESCRIPTION
Fix UI issues on transaction tables by improving mobile search layout and correcting desktop Actions column header styling.

The desktop Actions column header `id` was incorrectly set to `trx-header-mobile`, causing an unintended interior border radius due to mobile-specific CSS. This PR renames the ID to `trx-actions` and ensures it inherits default styling, resolving the issue. Mobile search field is now full width and has appropriate bottom padding.